### PR TITLE
Dev

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
   progress,
   ggspatial,
   RSelenium,
-  stringdist
+  stringdist,
+  stringi
 Depends: 
     R (>= 2.10)

--- a/R/find_chrome_v.R
+++ b/R/find_chrome_v.R
@@ -23,12 +23,7 @@ find_chrome_v <- function(){
   }
 
   driver_check <- function(){
-    tryCatch(expr = {
-      binman::list_versions("chromedriver")[[1]]
-    }, error=function(e){
-      message("Attempting to install chrome drivers...")
-      wdman::chrome()
-    })
+
 
     tryCatch(expr = {
       n <- stringdist::amatch(v, binman::list_versions("chromedriver")[[1]], maxDist = 10)[1]
@@ -52,6 +47,14 @@ find_chrome_v <- function(){
       return(v)
     })
   }
+
+  tryCatch(expr = {
+    invisible(binman::list_versions("chromedriver")[[1]])
+  }, error=function(e){
+    message("Attempting to install chrome drivers...")
+    wdman::chrome()
+  })
+
   if (!v %in% binman::list_versions("chromedriver")[[1]]) {
     v <- driver_check()
   }

--- a/R/find_chrome_v.R
+++ b/R/find_chrome_v.R
@@ -12,13 +12,13 @@ find_chrome_v <- function(){
     v <- system("google-chrome --version", intern=T) %>% # added 'intern=T' to capture output as char vector
       gsub("[^0-9.-]", "", .)
   } else {
-    stop("The `find_chrome_v()` function is not supported for this OS. \n
-    1) if you have never run Rselenium before, install the chrome driver with
-    `wdman::chrome()` \n
-    2) Check your chrome version by opening chrome > settings > About Chrome \n
-    3) Now run `binman::list_versions('chromedriver')` and pick the version
-    which most closely matches your own chrome version. \n
-    4) Make sure to include this version in the EAlidaR request. e.g.
+    stop("The `find_chrome_v()` function is not supported for this OS.
+    \n 1) if you have never run Rselenium before, install the chrome driver with
+    `wdman::chrome()`
+    \n 2) Check your chrome version by opening chrome > settings > About Chrome
+    \n 3) Now run `binman::list_versions('chromedriver')` and pick the version
+    which most closely matches your own chrome version.
+    \n 4) Make sure to include this version in the EAlidaR request. e.g.
          `get_area(Ashop_sf, 1, 'DTM', chrome_version='89.0.4389.23')`")
   }
 
@@ -29,19 +29,19 @@ find_chrome_v <- function(){
       n <- stringdist::amatch(v, binman::list_versions("chromedriver")[[1]], maxDist = 10)[1]
       v <- binman::list_versions("chromedriver")[[1]][n]
 
-      message(sprintf("No exact chrome driver match was found using: %s \n
-                      If an error occurs run binman::list_versions('chromedriver')`
-                      and try all options with the `chrome_verison` argument", v))
+      message(sprintf("No exact chrome driver match was found using: %s
+      \n If an error occurs run binman::list_versions('chromedriver')`
+      \n and try all options with the `chrome_verison` argument", v))
 
     },
     error=function(e){
       stop("Installed Chrome version is not listed under in
-      binman::list_versions('chromedriver')\n
-      Try The following: \n
-      1) Update Google Chrome... If this doesn't work then...\n
-      2) Run `binman::list_versions('chromedriver')` and pick the version which
-      most closely matches your own chrome version. \n
-      3) Make sure to include this version in the EAlidaR request. e.g.
+      binman::list_versions('chromedriver')
+      \n Try The following:
+      \n 1) Update Google Chrome... If this doesn't work then...
+      \n 2) Run `binman::list_versions('chromedriver')` and pick the version
+      which most closely matches your own chrome version.
+      \n 3) Make sure to include this version in the EAlidaR request. e.g.
            `get_area(Ashop_sf, 1, 'DTM', chrome_version='89.0.4389.23')`")
     }, finally = {
       return(v)


### PR DESCRIPTION
Fixed  the bug that resulted in: "~/geckodriver-v0.29.1-linux64.tar.gz.asc does not appear to be a zip or tar file." for ubunutu by adding {stringi} as a dependency. 

sorted out some formating with messages in find_chrome_v()